### PR TITLE
Update provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.0.2 - 2022-04-19 - Minor update
+
+#### Changes
+
+* Removed SPF support, since Selectel API no longer supports it
+* Fixed bug with wrong fqdn formatting during record deletion
+
+
 ## v0.0.1 - 2022-01-14 - Moving
 
 #### Nothworthy Changes

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ providers:
 
 #### Records
 
-SelectelProvider supports A, AAAA, CNAME, MX, NS, SPF, SRV, and TXT
+SelectelProvider supports A, AAAA, CNAME, MX, NS, SRV, and TXT
 
 #### Dynamic
 

--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -12,7 +12,7 @@ from octodns.record import Record, Update
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.1'
 
 
 def escape_semicolon(s):

--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -12,7 +12,7 @@ from octodns.record import Record, Update
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 def escape_semicolon(s):
@@ -29,7 +29,7 @@ class SelectelAuthenticationRequired(ProviderException):
 class SelectelProvider(BaseProvider):
     SUPPORTS_GEO = False
 
-    SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'TXT', 'SPF', 'SRV'))
+    SUPPORTS = set(('A', 'AAAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV'))
 
     MIN_TTL = 60
 
@@ -159,7 +159,6 @@ class SelectelProvider(BaseProvider):
     _params_for_AAAA = _params_for_multiple
     _params_for_NS = _params_for_multiple
     _params_for_TXT = _params_for_multiple
-    _params_for_SPF = _params_for_multiple
 
     _params_for_CNAME = _params_for_single
 
@@ -301,7 +300,7 @@ class SelectelProvider(BaseProvider):
         for record in records:
             full_domain = domain
             if zone:
-                full_domain = f'{zone}{domain}'
+                full_domain = f'{zone}.{domain}'
             if record['type'] == _type and record['name'] == full_domain:
                 path = f'/{domain_id}/records/{record["id"]}'
                 return self._request('DELETE', path)


### PR DESCRIPTION
* Remove SPF support since Selectel DNS no longer supports it
* Fix fqdn formating for delete_record(routine) when zone is
provided
---
Hello,
After extending external tests for communication with octodns we discovered one critical issue:
Records where name=origin name are deleted during change successfuly.
e.g. If we create zone with this config and then remove from config one of records, they will be deleted successfuly:
```yaml
---
? ''
: - ttl: 300
    type: A
    value: 10.10.10.10
  - ttl: 300
    type: AAAA
    value: ::AAAA:BBBB

```
However same actions with 3rd level labels in name:
```yaml
---
another:
  - ttl: 300
    type: A
    value: 10.10.10.10
  - ttl: 300
    type: AAAA
    value: ::AAAA:BBBB

```
will not remove records from account: Change to delete will be registred but after sync with `--doit'` record will not be deleted.   The cause: wrong string formatting in [delete_record](https://github.com/octodns/octodns-selectel/blob/5b4dbe780bdf839cb185724b5f99e14c72b6f4c4/octodns_selectel/__init__.py#304) routine.
```python
            if zone:
                full_domain = f'{zone}{domain}'
```
Zone if passed without trailing dot, and the easiest fix for this for us if just add dot in formating
`full_domain = f'{zone}.{domain}'`
