### PR TITLE
Add SSHFP support

### DIFF
--- a/tests/test_provider_octodns_selectel.py
+++ b/tests/test_provider_octodns_selectel.py
@@ -190,6 +190,26 @@ class TestSelectelProvider(TestCase):
         'value': 'little text',
     }))
 
+    # SSHFP
+    api_record.append({
+        'type': 'SSHFP',
+        'ttl': 800,
+        'algorithm': 1,
+        'fingerprint_type': 1,
+        'fingerprint': "123456789abcdef",
+        'id': 17,
+        'name': 'sshfp.unit.tests'
+    })
+    expected.add(Record.new(zone, 'sshfp', {
+        'ttl': 800,
+        'type': 'SSHFP',
+        'value': {
+            'algorithm': 1,
+            'fingerprint_type': 1,
+            'fingerprint': "123456789abcdef",
+        },
+    }))
+
     @requests_mock.Mocker()
     def test_populate(self, fake_http):
         zone = Zone('unit.tests.', [])
@@ -262,8 +282,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(8, len(plan.changes))
-        self.assertEqual(8, provider.apply(plan))
+        self.assertEqual(9, len(plan.changes))
+        self.assertEqual(9, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_domain_list(self, fake_http):
@@ -310,8 +330,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(8, len(plan.changes))
-        self.assertEqual(8, provider.apply(plan))
+        self.assertEqual(9, len(plan.changes))
+        self.assertEqual(9, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_delete_no_exist_record(self, fake_http):
@@ -363,8 +383,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(8, len(plan.changes))
-        self.assertEqual(8, provider.apply(plan))
+        self.assertEqual(9, len(plan.changes))
+        self.assertEqual(9, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_include_change_returns_false(self, fake_http):


### PR DESCRIPTION
We are planning to enable SSHFP records in our api this/next week, and we want that octodns was already prepared to work with this type.  

I assume version bump to 0.0.3 will be done in separate PR?