### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_provider_octodns_selectel.py
+++ b/tests/test_provider_octodns_selectel.py
@@ -345,7 +345,7 @@ class TestSelectelProvider(TestCase):
         )
         fake_http.post(f'{self.API_URL}/100000/records/', json=list())
 
-        provider = SelectelProvider(123, 'test_token')
+        provider = SelectelProvider(123, 'test_token', strict_supports=False)
 
         zone = Zone('unit.tests.', [])
 
@@ -404,7 +404,7 @@ class TestSelectelProvider(TestCase):
         )
         fake_http.post(f'{self.API_URL}/100000/records/', json=list())
 
-        provider = SelectelProvider(123, 'test_token')
+        provider = SelectelProvider(123, 'test_token', strict_supports=False)
 
         zone = Zone('unit.tests.', [])
 
@@ -470,7 +470,7 @@ class TestSelectelProvider(TestCase):
         fake_http.delete(f'{self.API_URL}/100000/records/100001', text="")
         fake_http.delete(f'{self.API_URL}/100000/records/100002', text="")
 
-        provider = SelectelProvider(123, 'test_token')
+        provider = SelectelProvider(123, 'test_token', strict_supports=False)
 
         zone = Zone('unit.tests.', [])
 


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957