### PR TITLE
Don't add extra dot to records which already have ending dot

### DIFF
--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -21,6 +21,13 @@ def escape_semicolon(s):
     return s.replace(';', '\\;')
 
 
+def require_root_domain(fqdn):
+    if fqdn.endswith('.'):
+        return fqdn
+
+    return f'{fqdn}.'
+
+
 class SelectelAuthenticationRequired(ProviderException):
     def __init__(self, msg):
         message = 'Authorization failed. Invalid or empty token.'
@@ -197,7 +204,7 @@ class SelectelProvider(BaseProvider):
         return {
             'ttl': records[0]['ttl'],
             'type': _type,
-            'values': [r["content"] if r["content"].endswith('.') else f'{r["content"]}.' for r in records]
+            'values': [require_root_domain(r["content"]) for r in records],
         }
 
     def _data_for_MX(self, _type, records):
@@ -206,7 +213,7 @@ class SelectelProvider(BaseProvider):
             values.append(
                 {
                     'preference': record['priority'],
-                    'exchange': record["content"] if record["content"].endswith('.') else f'{record["content"]}.',
+                    'exchange': require_root_domain(record["content"]),
                 }
             )
         return {'ttl': records[0]['ttl'], 'type': _type, 'values': values}
@@ -216,7 +223,7 @@ class SelectelProvider(BaseProvider):
         return {
             'ttl': only['ttl'],
             'type': _type,
-            'value': only["content"] if only["content"].endswith('.') else f'{only["content"]}.',
+            'value': require_root_domain(only["content"]),
         }
 
     _data_for_ALIAS = _data_for_CNAME
@@ -236,7 +243,7 @@ class SelectelProvider(BaseProvider):
                     'priority': record['priority'],
                     'weight': record['weight'],
                     'port': record['port'],
-                    'target': record["target"] if record["target"].endswith('.') else f'{record["target"]}.',
+                    'target': require_root_domain(record["target"]),
                 }
             )
 

--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -197,7 +197,7 @@ class SelectelProvider(BaseProvider):
         return {
             'ttl': records[0]['ttl'],
             'type': _type,
-            'values': [f'{r["content"]}.' for r in records],
+            'values': [r["content"] if r["content"].endswith('.') else f'{r["content"]}.' for r in records]
         }
 
     def _data_for_MX(self, _type, records):
@@ -206,7 +206,7 @@ class SelectelProvider(BaseProvider):
             values.append(
                 {
                     'preference': record['priority'],
-                    'exchange': f'{record["content"]}.',
+                    'exchange': record["content"] if record["content"].endswith('.') else f'{record["content"]}.',
                 }
             )
         return {'ttl': records[0]['ttl'], 'type': _type, 'values': values}
@@ -216,7 +216,7 @@ class SelectelProvider(BaseProvider):
         return {
             'ttl': only['ttl'],
             'type': _type,
-            'value': f'{only["content"]}.',
+            'value': only["content"] if only["content"].endswith('.') else f'{only["content"]}.',
         }
 
     _data_for_ALIAS = _data_for_CNAME
@@ -236,7 +236,7 @@ class SelectelProvider(BaseProvider):
                     'priority': record['priority'],
                     'weight': record['weight'],
                     'port': record['port'],
-                    'target': f'{record["target"]}.',
+                    'target': record["target"] if record["target"].endswith('.') else f'{record["target"]}.',
                 }
             )
 

--- a/tests/test_provider_octodns_selectel.py
+++ b/tests/test_provider_octodns_selectel.py
@@ -78,7 +78,9 @@ class TestSelectelProvider(TestCase):
     )
     expected.add(
         Record.new(
-            zone, 'wwwdot', {'ttl': 300, 'type': 'CNAME', 'value': 'unit.tests.'}
+            zone,
+            'wwwdot',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'unit.tests.'},
         )
     )
 
@@ -140,7 +142,11 @@ class TestSelectelProvider(TestCase):
             {
                 'ttl': 600,
                 'type': 'NS',
-                'values': ['ns1.unit.tests.', 'ns2.unit.tests.', 'ns3.unit.tests.'],
+                'values': [
+                    'ns1.unit.tests.',
+                    'ns2.unit.tests.',
+                    'ns3.unit.tests.',
+                ],
             },
         )
     )

--- a/tests/test_provider_octodns_selectel.py
+++ b/tests/test_provider_octodns_selectel.py
@@ -67,6 +67,21 @@ class TestSelectelProvider(TestCase):
         )
     )
 
+    api_record.append(
+        {
+            'type': 'CNAME',
+            'ttl': 300,
+            'content': 'unit.tests',
+            'name': 'wwwdot.unit.tests.',
+            'id': 12,
+        }
+    )
+    expected.add(
+        Record.new(
+            zone, 'wwwdot', {'ttl': 300, 'type': 'CNAME', 'value': 'unit.tests.'}
+        )
+    )
+
     # MX
     api_record.append(
         {
@@ -109,6 +124,15 @@ class TestSelectelProvider(TestCase):
             'id': 7,
         }
     )
+    api_record.append(
+        {
+            'type': 'NS',
+            'ttl': 600,
+            'content': 'ns3.unit.tests.',
+            'name': 'unit.tests',
+            'id': 7,
+        }
+    )
     expected.add(
         Record.new(
             zone,
@@ -116,7 +140,7 @@ class TestSelectelProvider(TestCase):
             {
                 'ttl': 600,
                 'type': 'NS',
-                'values': ['ns1.unit.tests.', 'ns2.unit.tests.'],
+                'values': ['ns1.unit.tests.', 'ns2.unit.tests.', 'ns3.unit.tests.'],
             },
         )
     )
@@ -352,8 +376,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(9, len(plan.changes))
-        self.assertEqual(9, provider.apply(plan))
+        self.assertEqual(10, len(plan.changes))
+        self.assertEqual(10, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_domain_list(self, fake_http):
@@ -411,8 +435,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(9, len(plan.changes))
-        self.assertEqual(9, provider.apply(plan))
+        self.assertEqual(10, len(plan.changes))
+        self.assertEqual(10, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_delete_no_exist_record(self, fake_http):
@@ -477,8 +501,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(9, len(plan.changes))
-        self.assertEqual(9, provider.apply(plan))
+        self.assertEqual(10, len(plan.changes))
+        self.assertEqual(10, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_include_change_returns_false(self, fake_http):


### PR DESCRIPTION
Module add extra dot every time when read data but passing through original data on save. This lead us to double enddot for a full domain name

domain.unit.tests. became domain.init.tests..

This fix will avoid adding extra dot when it's already there