### PR TITLE
Remove escaping func for TXT content to fix constant update of TXT records

### DIFF
--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -17,11 +17,6 @@ from octodns.record import Record, Update
 __version__ = __VERSION__ = '0.0.3'
 
 
-def escape_semicolon(s):
-    assert s
-    return s.replace(';', '\\;')
-
-
 def require_root_domain(fqdn):
     if fqdn.endswith('.'):
         return fqdn
@@ -233,7 +228,7 @@ class SelectelProvider(BaseProvider):
         return {
             'ttl': records[0]['ttl'],
             'type': _type,
-            'values': [escape_semicolon(r['content']) for r in records],
+            'values': [r['content'] for r in records],
         }
 
     def _data_for_SRV(self, _type, records):


### PR DESCRIPTION
Escaping semicolumn function, apparently redundant and causes always update of TXT records.  
We can not provide unescaped ";"  since errors is risen from this validation process: 
https://github.com/octodns/octodns/blob/main/octodns/record/chunked.py#L53
So removed func always adds extra slash, which forces octodns during sync to think that updated is required.
e.g.
We have record described as:
```yaml
some-txt:
  ttl: 120
  type: TXT
  value: v=DKIM1\; k=rsa\; p=MIG
```
Which during sync will say:
```
* selectel (SelectelProvider)
*   Create <TxtRecord TXT 120, some-txt.octodns-chirkov.com., ['v=DKIM1\; k=rsa\; p=MIG']> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing Records=0
```
But if do sync again:
```
* selectel (SelectelProvider)
*   Update
*     <TxtRecord TXT 120, some-txt.octodns-chirkov.com., ['v=DKIM1\\; k=rsa\\; p=MIG']> ->
*     <TxtRecord TXT 120, some-txt.octodns-chirkov.com., ['v=DKIM1\; k=rsa\; p=MIG']> (config)
*   Summary: Creates=0, Updates=1, Deletes=0, Existing Records=1
```
While on the server side result will remain the same `v=DKIM1\; k=rsa\; p=MIG`