### PR TITLE
Rel v0.0.4 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.0.4 - 2023-12-06 - Bug fix
+
+#### Changes
+
+* Remove function forcing escaping semicolon in TXT content which caused record updating even if no changes were done to it 
+
+
 ## v0.0.3 - 2022-09-01 - New records and bug fix
 
 #### Changes

--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -14,7 +14,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.3'
+__version__ = __VERSION__ = '0.0.4'
 
 
 def require_root_domain(fqdn):


### PR DESCRIPTION
Update change log and version for new release.

@ross 
Also a question for you. We are going to public v2 version of our API soon and v1 will be supported for a while, what is expected way to update our plugin when just do changes and bump major version(from 0 -> 1)?