### PR TITLE
Bump version to 0.99.0 and fix `version` variable to match PEP/rest of octoDNS

### DIFF
--- a/octodns_selectel/__init__.py
+++ b/octodns_selectel/__init__.py
@@ -1,4 +1,9 @@
 from .v1.provider import SelectelProvider as SelectelProviderLegacy
 from .v2.provider import SelectelProvider as SelectelProvider
+from .version import __VERSION__, __version__
 
 __all__ = [SelectelProviderLegacy, SelectelProvider]
+
+# quell warnings
+__VERSION__
+__version__

--- a/octodns_selectel/v1/provider.py
+++ b/octodns_selectel/v1/provider.py
@@ -4,12 +4,12 @@ from logging import getLogger
 from requests import Session
 from requests.exceptions import HTTPError
 
-from octodns import __VERSION__ as octodns_version
+from octodns import __version__ as octodns_version
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 from octodns.record import Record, Update
 
-from octodns_selectel.version import version as provider_version
+from octodns_selectel.version import __version__ as provider_version
 
 
 def require_root_domain(fqdn):

--- a/octodns_selectel/v2/dns_client.py
+++ b/octodns_selectel/v2/dns_client.py
@@ -1,6 +1,6 @@
 from requests import Session
 
-from octodns import __VERSION__ as octodns_version
+from octodns import __version__ as octodns_version
 
 from .exceptions import ApiException
 

--- a/octodns_selectel/v2/provider.py
+++ b/octodns_selectel/v2/provider.py
@@ -8,7 +8,7 @@ from octodns.idna import idna_decode
 from octodns.provider.base import BaseProvider
 from octodns.record import Record, SshfpRecord, Update
 
-from octodns_selectel.version import version as provider_version
+from octodns_selectel.version import __version__ as provider_version
 
 from .dns_client import DNSClient
 from .exceptions import ApiException

--- a/octodns_selectel/version.py
+++ b/octodns_selectel/version.py
@@ -1,1 +1,2 @@
-version = '0.0.4'
+# TODO: remove __VERSION__ w/2.x
+__version__ = __VERSION__ = '0.0.4'

--- a/octodns_selectel/version.py
+++ b/octodns_selectel/version.py
@@ -1,2 +1,2 @@
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '0.0.4'
+__version__ = __VERSION__ = '0.99.0'

--- a/script/release
+++ b/script/release
@@ -33,7 +33,7 @@ fi
 # Set so that setup.py will create a public release style version number
 export OCTODNS_RELEASE=1
 
-VERSION="$(grep "^version" "$ROOT/octodns_selectel/version.py" | sed -e "s/.* = '//" -e "s/'$//")"
+VERSION="$(grep "^__version__" "$ROOT/octodns_selectel/version.py" | sed -e "s/.* = '//" -e "s/'$//")"
 
 git tag -s "v$VERSION" -m "Release $VERSION"
 git push origin "v$VERSION"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def descriptions():
 def version():
     with open('octodns_selectel/version.py') as fh:
         for line in fh:
-            if line.startswith('version'):
+            if line.startswith('__version__'):
                 return line.split("'")[1]
     return 'unknown'
 


### PR DESCRIPTION
## v0.99.0 - 2024-02-01 - Support for DNSv2 API and structural project changes

#### Changes

* Move existing provider and related tests to separate directories `v1`
* Rename public name from `SelectelProvider` to `SelectelProviderLegacy`
* Add `list_zones()` method to support "*" for planning
* Fix SSHFP parsing bug, caused by trailing dot in fingerprint which lead to constant re-update of record
* Move version varible to separate file, since now it is utilized by two providers. Storing it in `__init__.py` causes cycling imports
* Update `script/release` and `setup.py` to parse version from another location
* Update `readme.md` with focus on new provider

#### New

* Add new `SelectelProvider` class to support v2 API
* Isolate API calls into separate class
* Add tests for SelectelProvider