### PR TITLE
Added escaping semicolon for TXT records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.99.2 - 2024-03-13 - Add escaping semicolon for TXT records
+## v0.99.2 - 2024-03-14 - Add escaping semicolon for TXT records
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.99.2 - 2024-03-13 - Add escaping semicolon for TXT records
+
+#### Changes
+
+* Add escaping semicolon for TXT records in `SelectelProvider` and `SelectelProviderLegacy`
+
+
 ## v0.99.1 - 2024-02-01 - Fix project structure for distribution
 
 #### Changes

--- a/octodns_selectel/escaping_semicolon.py
+++ b/octodns_selectel/escaping_semicolon.py
@@ -1,0 +1,6 @@
+def escape_semicolon(s):
+    return s.replace(';', '\\;')
+
+
+def unescape_semicolon(s):
+    return s.replace('\\;', ';')

--- a/octodns_selectel/v2/mappings.py
+++ b/octodns_selectel/v2/mappings.py
@@ -1,5 +1,10 @@
 from string import Template
 
+from octodns_selectel.escaping_semicolon import (
+    escape_semicolon,
+    unescape_semicolon,
+)
+
 from .exceptions import SelectelException
 
 
@@ -17,7 +22,8 @@ def to_selectel_rrset(record):
         rrset_records = [{'content': record.value}]
     elif record._type == "TXT":
         rrset_records = [
-            dict(content=f'\"{value}\"') for value in record.values
+            dict(content=f'\"{unescape_semicolon(value)}\"')
+            for value in record.values
         ]
     elif record._type == "MX":
         rrset_records = list(
@@ -76,7 +82,10 @@ def to_octodns_record_data(rrset):
         key_for_record_values = "value"
         record_values = rrset["records"][0]["content"]
     elif rrset_type == "TXT":
-        record_values = [r['content'].strip('"\'') for r in rrset["records"]]
+        record_values = [
+            escape_semicolon(r['content']).strip('"\'')
+            for r in rrset["records"]
+        ]
     elif rrset_type == "MX":
         for record in rrset["records"]:
             preference, exchange = record["content"].split(" ")

--- a/tests/v1/test_provider_octodns_selectel_v1.py
+++ b/tests/v1/test_provider_octodns_selectel_v1.py
@@ -259,6 +259,28 @@ class TestSelectelProvider(TestCase):
         )
     )
 
+    # TXT with semicolon
+    api_record.append(
+        {
+            'type': 'TXT',
+            'ttl': 300,
+            'content': 'v=DKIM1; k=rsa; p=some-key',
+            'name': 'dkim.unit.tests',
+            'id': 18,
+        }
+    )
+    expected.add(
+        Record.new(
+            zone,
+            'dkim',
+            {
+                'ttl': 200,
+                'type': 'TXT',
+                'value': 'v=DKIM1\\; k=rsa\\; p=some-key',
+            },
+        )
+    )
+
     # SSHFP
     api_record.append(
         {
@@ -378,8 +400,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(10, len(plan.changes))
-        self.assertEqual(10, provider.apply(plan))
+        self.assertEqual(11, len(plan.changes))
+        self.assertEqual(11, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_domain_list(self, fake_http):
@@ -450,8 +472,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(10, len(plan.changes))
-        self.assertEqual(10, provider.apply(plan))
+        self.assertEqual(11, len(plan.changes))
+        self.assertEqual(11, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_delete_no_exist_record(self, fake_http):
@@ -516,8 +538,8 @@ class TestSelectelProvider(TestCase):
             zone.add_record(record)
 
         plan = provider.plan(zone)
-        self.assertEqual(10, len(plan.changes))
-        self.assertEqual(10, provider.apply(plan))
+        self.assertEqual(11, len(plan.changes))
+        self.assertEqual(11, provider.apply(plan))
 
     @requests_mock.Mocker()
     def test_include_change_returns_false(self, fake_http):

--- a/tests/v2/test_selectel_mappings.py
+++ b/tests/v2/test_selectel_mappings.py
@@ -269,6 +269,8 @@ class TestSelectelMappings(TestCase):
 
     def test_mapping_record_txt(self):
         txt_list = ["\"Buzz\"", "\"Fizz\""]
+        unescaping_dkim_value = "\"v=DKIM1; k=rsa; p=some-key\""
+        escaping_dkim_value = "\"v=DKIM1\\; k=rsa\\; p=some-key\""
         test_pairs = (
             PairTest(
                 TxtRecord(
@@ -305,6 +307,19 @@ class TestSelectelMappings(TestCase):
                         dict(content=txt_list[0]),
                         dict(content=txt_list[1]),
                     ],
+                ),
+            ),
+            PairTest(
+                TxtRecord(
+                    self.zone,
+                    "dkim",
+                    dict(ttl=self.ttl, value=escaping_dkim_value),
+                ),
+                dict(
+                    name=f"dkim.{self.zone.name}",
+                    ttl=self.ttl,
+                    type="TXT",
+                    records=[dict(content=unescaping_dkim_value)],
                 ),
             ),
         )


### PR DESCRIPTION
Added escaping semicolon for TXT records in `SelectelProvider` and `SelectelProviderLegacy`.
It necessary for DKIM records.
[Similar functionality](https://github.com/octodns/octodns/pull/272) in Azure octodns provider.