### PR TITLE
Version 0.99.2 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Add escaping semicolon for TXT records in `SelectelProvider` and `SelectelProviderLegacy`
 
-
 ## v0.99.1 - 2024-02-01 - Fix project structure for distribution
 
 #### Changes

--- a/octodns_selectel/version.py
+++ b/octodns_selectel/version.py
@@ -1,2 +1,2 @@
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '0.99.1'
+__version__ = __VERSION__ = '0.99.2'


### PR DESCRIPTION
## v0.99.2 - 2024-03-14 - Add escaping semicolon for TXT records

#### Changes

* Add escaping semicolon for TXT records in `SelectelProvider` and `SelectelProviderLegacy`