### PR TITLE
Version 0.99.3 bump & Changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.99.3 - 2024-05-06 - Add supporting DNAME and CAA records
+
+#### Changes
+
+* Add supporting DNAME and CAA records in `SelectelProvider`
+
 ## v0.99.2 - 2024-03-14 - Add escaping semicolon for TXT records
 
 #### Changes

--- a/octodns_selectel/version.py
+++ b/octodns_selectel/version.py
@@ -1,2 +1,2 @@
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '0.99.2'
+__version__ = __VERSION__ = '0.99.3'


### PR DESCRIPTION
We have lost focuse and forgotten to provide PR with CHANGELOG to bump version after last commits

Here it is.