### PR TITLE
Fix bug with duplicates record error on big zones

### DIFF
--- a/octodns_selectel/v2/dns_client.py
+++ b/octodns_selectel/v2/dns_client.py
@@ -7,7 +7,7 @@ from .exceptions import ApiException
 
 class DNSClient:
     API_URL = 'https://api.selectel.ru/domains/v2'
-    _PAGINATION_LIMIT = 50
+    _PAGINATION_LIMIT = 1000
 
     _zone_path = "/zones"
     __rrsets_path = "/zones/{}/rrset"
@@ -61,7 +61,7 @@ class DNSClient:
     def _request_all_entities(self, path, offset=0):
         items = []
         resp = self._request(
-            "GET", path, dict(limit=self._PAGINATION_LIMIT, offset=offset)
+            "GET", path, dict(limit=self._PAGINATION_LIMIT, offset=offset, sort_by="name.descend")
         )
         items.extend(resp["result"])
         if next_offset := resp["next_offset"]:

--- a/octodns_selectel/v2/dns_client.py
+++ b/octodns_selectel/v2/dns_client.py
@@ -61,9 +61,9 @@ class DNSClient:
     def _request_all_entities(self, path, offset=0):
         items = []
         resp = self._request(
-            "GET", 
-            path, 
-            dict(limit=self._PAGINATION_LIMIT, offset=offset, sort_by="name.descend")
+            "GET",
+            path,
+            dict(limit=self._PAGINATION_LIMIT, offset=offset, sort_by="name.descend"),
         )
         items.extend(resp["result"])
         if next_offset := resp["next_offset"]:

--- a/octodns_selectel/v2/dns_client.py
+++ b/octodns_selectel/v2/dns_client.py
@@ -63,7 +63,11 @@ class DNSClient:
         resp = self._request(
             "GET",
             path,
-            dict(limit=self._PAGINATION_LIMIT, offset=offset, sort_by="name.descend"),
+            dict(
+                limit=self._PAGINATION_LIMIT,
+                offset=offset,
+                sort_by="name.descend",
+            ),
         )
         items.extend(resp["result"])
         if next_offset := resp["next_offset"]:

--- a/octodns_selectel/v2/dns_client.py
+++ b/octodns_selectel/v2/dns_client.py
@@ -61,7 +61,9 @@ class DNSClient:
     def _request_all_entities(self, path, offset=0):
         items = []
         resp = self._request(
-            "GET", path, dict(limit=self._PAGINATION_LIMIT, offset=offset, sort_by="name.descend")
+            "GET", 
+            path, 
+            dict(limit=self._PAGINATION_LIMIT, offset=offset, sort_by="name.descend")
         )
         items.extend(resp["result"])
         if next_offset := resp["next_offset"]:

--- a/tests/v2/test_selectel_dns_client.py
+++ b/tests/v2/test_selectel_dns_client.py
@@ -14,7 +14,7 @@ class TestSelectelDNSClient(TestCase):
     library_version = "0.0.1"
     openstack_token = "some-openstack-token"
     dns_client = DNSClient(library_version, openstack_token)
-    _PAGINATION_LIMIT = 50
+    _PAGINATION_LIMIT = 1000
     _PAGINATION_OFFSET = 0
     _rrsets = [
         dict(


### PR DESCRIPTION
The selectel api has a bug: when requesting records from a zone without specifying a sort, it returns records in a random order. This leads to duplicate records error when requesting records in several iterations (if there are more records than _PAGINATION_LIMIT). 
Besides, **name.ascend** sort returns records in random order too. But **name.descend** sort returns records in fixed order

 I also increase _PAGINATION_LIMIT to Selectel API defaults (1000) to reduce the number of http requests to the API