### PR TITLE
Fix space in value of CAA record

### DIFF
--- a/octodns_selectel/v2/mappings.py
+++ b/octodns_selectel/v2/mappings.py
@@ -98,9 +98,9 @@ def to_octodns_record_data(rrset):
         ]
     elif rrset_type == "CAA":
         for record in rrset["records"]:
-            flag, tag, value = record["content"].split(" ")
+            flag, tag, value = record["content"].split(" ", 2)
             record_values.append(
-                {'flags': flag, 'tag': tag, 'value': value.strip("\"")}
+                {'flags': flag, 'tag': tag, 'value': value.strip('"')}
             )
     elif rrset_type == "MX":
         for record in rrset["records"]:

--- a/tests/v2/test_selectel_mappings.py
+++ b/tests/v2/test_selectel_mappings.py
@@ -629,6 +629,11 @@ class TestSelectelMappings(TestCase):
             dict(
                 flags="0", tag="iodef", value="mailto:notification@example.com"
             ),
+            dict(
+                flags="0",
+                tag="issue",
+                value="otherca.com; accounturi=https://otherca.com/acct/123456",
+            ),
         ]
         caa_list_str = [
             self._caa_to_string(caa_dict_item)


### PR DESCRIPTION
I fixed work with CAA records which includes spaces in its values.
Resolve this [issue](https://github.com/octodns/octodns-selectel/issues/55).

After merge this PR I will bump it and will update changelog.

Before merge my pull request with new changes please update version with changes in previous [pull request](https://github.com/octodns/octodns-selectel/pull/59).