### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
+
+* Require octodns >= 1.5.0
+
 ## v0.99.4 - 2025-03-18 - Bug fix
 
 #### Changes

--- a/octodns_selectel/version.py
+++ b/octodns_selectel/version.py
@@ -1,2 +1,2 @@
 # TODO: remove __VERSION__ w/2.x
-__version__ = __VERSION__ = '0.99.4'
+__version__ = __VERSION__ = '1.0.0'


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - Long overdue 1.0

* Require octodns >= 1.5.0